### PR TITLE
Fix getSendUtxo logic

### DIFF
--- a/src/services/utxoHelper.ts
+++ b/src/services/utxoHelper.ts
@@ -306,7 +306,7 @@ export const getSendUtxo = (code: string, amount: BigInt, utxoDataList: AddUtxoI
 
     const credit = BigInt(Number(sum) - Number(amount));
     const remainedDebt = _amount - credit;
-    const amountToUse = credit ? remainedDebt : _amount;
+    const amountToUse = credit > 0 ? remainedDebt : _amount;
 
     result.push({
       amount: amountToUse,


### PR DESCRIPTION
This condition is always returning true and hence `remainedDebt` is being used all the time. This is a problem because the way how the logic is written, anytime a transfer is initiated with amount greater than the latest UTXO, this function tries to use amount greater than what that UTXO has and hence the transfer will fail.