### PR TITLE
Extend the execution timeout for TM tests

### DIFF
--- a/src/tripleMasking/tripleMasking.integration.spec.ts
+++ b/src/tripleMasking/tripleMasking.integration.spec.ts
@@ -2,7 +2,7 @@ import * as Integration from './tripleMasking.integration';
 
 import { waitForBlockChange } from '../evm/testHelpers';
 
-const extendedExecutionTimeout = 180000;
+const extendedExecutionTimeout = 360000;
 
 afterAll(async (done: any) => {
   console.log('after all - just waiting for 3 blocks to have all pending requests finished (if any)');

--- a/src/tripleMasking/tripleMasking.integration.spec.ts
+++ b/src/tripleMasking/tripleMasking.integration.spec.ts
@@ -2,7 +2,7 @@ import * as Integration from './tripleMasking.integration';
 
 import { waitForBlockChange } from '../evm/testHelpers';
 
-const extendedExecutionTimeout = 360000;
+const extendedExecutionTimeout = 540000;
 
 afterAll(async (done: any) => {
   console.log('after all - just waiting for 3 blocks to have all pending requests finished (if any)');


### PR DESCRIPTION
Integration tests are failing on TM devnet (qa01) and jenkins nighty because the tests are taking longer than the previous timeout limit.