### PR TITLE
Update solc version

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "nodemon": "^2.0.7",
     "path-browserify": "^1.0.1",
     "prettier": "^2.2.1",
-    "solc": "0.4.17",
+    "solc": "0.4.26",
     "stream-browserify": "^3.0.0",
     "ts-jest": "^26.4.4",
     "ts-loader": "^8.0.13",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8485,10 +8485,10 @@ snapdragon@^0.8.1:
     source-map-resolve "^0.5.0"
     use "^3.1.0"
 
-solc@0.4.17:
-  version "0.4.17"
-  resolved "https://registry.yarnpkg.com/solc/-/solc-0.4.17.tgz#75f93da6bc190becb89f6663076ab943ff95cd2f"
-  integrity sha512-39Tmo2r+qclwW7ooLXMLzMSxmoGtHy3/p2sDKdA9NM/+MRtzLm/AFKj4BY2Cocg3gwkfJzKTEx6X0wiI4fIZ/A==
+solc@0.4.26:
+  version "0.4.26"
+  resolved "https://registry.yarnpkg.com/solc/-/solc-0.4.26.tgz#5390a62a99f40806b86258c737c1cf653cc35cb5"
+  integrity sha512-o+c6FpkiHd+HPjmjEVpQgH7fqZ14tJpXhho+/bQXlXbliLIS/xjXb42Vxh+qQY1WCSTMQ0+a5vR9vi0MfhU6mA==
   dependencies:
     fs-extra "^0.30.0"
     memorystream "^0.3.1"


### PR DESCRIPTION
This is suggested by Jenkins.

17:12:31 (node:9982) V8: /tmp/jenkins-c2ad2668/workspace/develop-PR-test/findora-sdk/node_modules/solc/soljson.js:3 Invalid asm.js: Invalid member of stdlib
17:12:31 (Use `node --trace-warnings ...` to show where the warning was created)